### PR TITLE
fix: missing branch will prevent submodule update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,4 @@
 [submodule "atala-prism-wallet-sdk-ts"]
 	path = atala-prism-wallet-sdk-ts
 	url = https://github.com/input-output-hk/atala-prism-wallet-sdk-ts.git
+	branch = main


### PR DESCRIPTION
Locally, after the renaming of the wallet sdk ts, the generation of the submodule was not working. 
Adding the branch information is fixing this.