### PR TITLE
fix: link to edge agent swift

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -15,10 +15,10 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to deploy, e.g. v1.0.0"
+        description: "Document tag to deploy, e.g v1.76.1"
         required: true
       env:
-        description: "Environment to trigger update on"
+        description: "Target environment: staging or production"
         required: false
         default: "staging"
   push:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -131,16 +131,16 @@ const config = {
                         position: 'left',
                         items: [
                             {
-                                label: 'Edge SDK Swift',
-                                href: 'https://input-output-hk.github.io/atala-prism-wallet-sdk-swift/documentation/atalaprismsdk',
+                                label: 'Edge Agent SDK Swift',
+                                href: 'https://input-output-hk.github.io/atala-prism-wallet-sdk-swift/documentation/edgeagentsdk',
                             },
                             {
                                 to: '/atala-prism-wallet-sdk-ts/sdk',
-                                label: 'Edge SDK Typescript',
+                                label: 'Edge Agent SDK Typescript',
                                 activeBaseRegex: `/atala-prism-wallet-sdk-ts/sdk`
                             },
                             {
-                                label: 'Edge SDK Kotlin Multiplatform',
+                                label: 'Edge Agent SDK Kotlin Multiplatform',
                                 href: 'https://input-output-hk.github.io/atala-prism-wallet-sdk-kmm/',
                             },
                         ],


### PR DESCRIPTION
Update the broken link for Swift SDK

And update #79 for the clarification on the deployment of the docs inputs